### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,1 @@
-# Traffic-Clusters
-This project  compares clusters of 311 traffic complaints made in May 2017 to locations of construction sites ongoing during the same time period. 
-
-Both data sets were obtained from NYC Open Data, with the only modification being to geocode the addresses in the construction data (the 311 data already has XY coordinates projected in EPSG:2263 - New York/Long Island).
-
-My first step was to visualize the data in order to get a look, shown here:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Traffic-Clusters
-Spatial analysis of 311 traffic complaints and lower Manhattan construction sites
+This project  compares clusters of 311 traffic complaints made in May 2017 to locations of construction sites ongoing during the same time period. 
+
+Both data sets were obtained from NYC Open Data, with the only modification being to geocode the addresses in the construction data (the 311 data already has XY coordinates projected in EPSG:2263 - New York/Long Island).
+
+My first step was to visualize the data in order to get a look, shown here:
+


### PR DESCRIPTION
This project  compares clusters of 311 traffic complaints made in May 2017 to locations of construction sites ongoing during the same time period. It was completed using R.

Both data sets were obtained from NYC Open Data, with the only modification being to geocode the addresses in the construction data (the 311 data already has XY coordinates projected in EPSG:2263 - New York/Long Island).

The first step is to visualize the data in order to get a look at it, shown here:

![initial_plot](https://user-images.githubusercontent.com/28580648/29744520-7916877e-8a74-11e7-8969-0f542612c00a.jpeg)

The data isn't clustered too tightly, so to get a more refined dataset to work with we can zoom in specifically on lower Manhattan:

![initial_lowman](https://user-images.githubusercontent.com/28580648/29744560-ec7adc88-8a74-11e7-93ef-dee6a6e104dc.jpeg)

Using standard deviation ellipses, we can analyze whether 311 traffic complaints were clustered (statistically) in particular areas and compare those areas to the locations of constructions sites. A standard deviation ellipse of 311 traffic complaints highlights an area within one standard deviation of a particular cluster's center point.

Eyeballing the data, there appear to be roughly four main cluster areas in lower Manhattan. We can generate one standard deviation ellipse for each one:

![clusters](https://user-images.githubusercontent.com/28580648/29744872-906a0714-8a7b-11e7-974e-54824c3c4b95.jpeg)

Let's look at just the ellipses and the construction sites. Remember that the ellipses are generated only from the 311 traffic complaint data. So if the centers of any of the ellipses match any construction sites, we might have a statistical link (this is assuming a normal distribution of complaints around the construction sites; since this data is only from people who bothered to call 311 to complain about traffic, it's possible the data just doesn't accurately reflect traffic patterns around construction sites).

![ellipses-consites](https://user-images.githubusercontent.com/28580648/29744873-963cc49c-8a7b-11e7-9554-7c312476e1cf.jpeg)

So it appears the traffic complaints are not clustered around any construction sites (there's only one that lies anywhere near an ellipse center, but it's also the one nearest to the Holland tunnel - big surprise).

We can still go a bit further. Let's find the centerpoint for each dataset - the traffic complaints and the construction - respectively.

![traf-const-centers](https://user-images.githubusercontent.com/28580648/29744937-e46b3d32-8a7c-11e7-8549-253a8a734407.jpeg)

So the ellipse centers _are_ near each other - but do they represent populations that are spatially linked with statistical significance?

We can test this with by calculating the mean minimum distance in a randomized simulation. First we calculate the distance between all sets of points for each dataset; then we combine and randomize both datasets and again calculate the distance between all points. We do this all numerous times and find the mean minimum distance - if it is close (within statistical significance) to the original minimum distance, then there is evidence of a statistical link.

Let's try it:

The initial mean minimum distance is 1234.008.

The mean minimum distance after 100 randomized simulations is 407.4928. Nowhere near each other!

Shown visually:

![calc-results](https://user-images.githubusercontent.com/28580648/29745024-11d21a28-8a7f-11e7-9c3e-140da3c416da.jpeg)
 
The red line in the graph is our mean randomized minimum distance - as you can see, the numbers are so far apart that our initial mean minimum distance isn't even within the paramaters of the graph. _Way_ out of statistical significance!

So we can soundly conclude that, given this specific data, there did not appear to be any statistically significant spatial linkage between construction sites and 311 traffic complaints in lower Manhattan in May 2017.